### PR TITLE
fix: improve Popover spacing and picker width

### DIFF
--- a/src/components/color-picker-demo.tsx
+++ b/src/components/color-picker-demo.tsx
@@ -19,7 +19,7 @@ export const ColorPickerDemo = () => {
         <h2>Color picker</h2>
         <ColorPicker
           onChange={(v) => {
-            setColor(v);
+            setColor(v as string);
           }}
           value={color}
         />
@@ -28,7 +28,7 @@ export const ColorPickerDemo = () => {
         <ColorPicker
           disabled
           onChange={(v) => {
-            setColor(v);
+            setColor(v as string);
           }}
           value={color}
         />

--- a/src/components/ui/color-picker.tsx
+++ b/src/components/ui/color-picker.tsx
@@ -53,8 +53,12 @@ const ColorPicker = forwardRef<
             <div />
           </Button>
         </PopoverTrigger>
-        <PopoverContent className='w-full'>
-          <HexColorPicker color={parsedValue} onChange={onChange} />
+        <PopoverContent className='flex flex-col gap-4 w-full'>
+          <HexColorPicker
+            color={parsedValue}
+            onChange={onChange}
+            className='!w-full'
+          />
           <Input
             maxLength={7}
             onChange={(e) => {


### PR DESCRIPTION
* Added `flex flex-col gap-4` to `PopoverContent` for better spacing
* Applied `!w-full` to `HexColorPicker` to ensure full container width
* Fixed ESLint issue by explicitly typing `setColor(v as string)`